### PR TITLE
remove body-parser

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "@types/react-dom": "^16.8.4",
     "@types/react-redux": "^7.1.10",
     "babel-polyfill": "^6.26.0",
-    "body-parser": "^1.19.0",
     "express": "^4.16.3",
     "mongoose": "^5.10.11",
     "react": "^16.5.2",

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1,17 +1,18 @@
 
 import express, {Request, Response, Router, Express} from 'express';
-import bodyParser from 'body-parser';
 import router from './route';
 import DBConnect from "./dbConfigs";
+import { RequestHandler } from 'express-serve-static-core';
 
 // call express
 const app: Express = express(); // define our app using express
 
 // configure app to use bodyParser for
 // Getting data from body of requests
-app.use(bodyParser.json());
+app.use(express.urlencoded({extended: true}) as RequestHandler);
 
-app.use(bodyParser.urlencoded({extended: true}));
+app.use(express.json() as RequestHandler) 
+
 
 const port: number = Number(process.env.PORT) || 8050; // set our port
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1720,7 +1720,7 @@ bn.js@^5.0.0, bn.js@^5.1.1:
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-5.1.3.tgz#beca005408f642ebebea80b042b4d18d2ac0ee6b"
   integrity sha512-GkTiFpjFtUzU9CbMeJ5iazkCzGL3jrhzerzZIuqLABjbwRaFt33I9tUdSNryIptM+RxDet6OKm2WnLXzW51KsQ==
 
-body-parser@1.19.0, body-parser@^1.19.0:
+body-parser@1.19.0:
   version "1.19.0"
   resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.19.0.tgz#96b2709e57c9c4e09a6fd66a8fd979844f69f08a"
   integrity sha512-dhEPs72UPbDnAQJ9ZKMNTP6ptJaionhP5cBb541nXPlW60Jepo9RV/a4fX4XWW9CuFNK22krhrj1+rgzifNCsw==


### PR DESCRIPTION
If you are using Express 4.16+ you don't have to import body-parser anymore, as JSON and URL-encoded middleware are bundled in express itself.
Also, the code editor was showing warning 
``` Argument of type 'NextHandleFunction' is not assignable to parameter of type 'PathParams' ```
Fixed it as well.